### PR TITLE
7zip v25.01

### DIFF
--- a/recipe/LICENSE.txt
+++ b/recipe/LICENSE.txt
@@ -3,24 +3,26 @@
   License for use and distribution
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-  7-Zip Copyright (C) 1999-2019 Igor Pavlov.
+  7-Zip Copyright (C) 1999-2025 Igor Pavlov.
 
   The licenses for files are:
 
-    1) CPP/7zip/Compress/Rar* files: the "GNU LGPL" with "unRAR license restriction"
-    2) CPP/7zip/Compress/LzfseDecoder.cpp: the "BSD 3-clause License"
-    3) Some files are "public domain" files, if "public domain" status is stated in source file.
-    4) the "GNU LGPL" for all other files. If there is no license information in 
+    - CPP/7zip/Compress/Rar* files: the "GNU LGPL" with "unRAR license restriction"
+    - CPP/7zip/Compress/LzfseDecoder.cpp: the "BSD 3-clause License"
+    - C/ZstdDec.c: the "BSD 3-clause License"
+    - C/Xxh64.c: the "BSD 2-clause License"
+    - Some files are "public domain" files, if "public domain" status is stated in source file.
+    - the "GNU LGPL" for all other files. If there is no license information in
        some source file, that file is under the "GNU LGPL".
 
-  The "GNU LGPL" with "unRAR license restriction" means that you must follow both 
+  The "GNU LGPL" with "unRAR license restriction" means that you must follow both
   "GNU LGPL" rules and "unRAR license restriction" rules.
 
 
 
 
-  GNU LGPL information
-  --------------------
+GNU LGPL information
+--------------------
 
     This library is free software; you can redistribute it and/or
     modify it under the terms of the GNU Lesser General Public
@@ -33,58 +35,117 @@
     Lesser General Public License for more details.
 
     You should have received a copy of the GNU Lesser General Public
-    License along with this library; if not, write to the Free Software
-    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+    License along with this library; if not,
+    you can get a copy of the GNU Lesser General Public License from
+    http://www.gnu.org/
 
 
 
 
-  BSD 3-clause License
-  --------------------
+BSD 3-clause License in 7-Zip code
+----------------------------------
 
-    The "BSD 3-clause License" is used for the code in LzfseDecoder.cpp that implements LZFSE data decompression.
-    That code was derived from the code in the "LZFSE compression library" developed by Apple Inc,
-    that also uses the "BSD 3-clause License":
+  The "BSD 3-clause License" is used for the following code in 7z.dll
+    1) LZFSE data decompression.
+         CPP/7zip/Compress/LzfseDecoder.cpp.
+       That code was derived from the code in the "LZFSE compression library" developed by Apple Inc,
+       that also uses the "BSD 3-clause License".
+    2) ZSTD data decompression.
+         C/ZstdDec.c
+       that code was developed using original zstd decoder code as reference code.
+       The original zstd decoder code was developed by Facebook Inc,
+       that also uses the "BSD 3-clause License".
 
-    ----
-    Copyright (c) 2015-2016, Apple Inc. All rights reserved.
+  Copyright (c) 2015-2016, Apple Inc. All rights reserved.
+  Copyright (c) Facebook, Inc. All rights reserved.
+  Copyright (c) 2023-2025 Igor Pavlov.
 
-    Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Text of the "BSD 3-clause License"
+----------------------------------
 
-    1.  Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-    2.  Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer
-        in the documentation and/or other materials provided with the distribution.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
 
-    3.  Neither the name of the copyright holder(s) nor the names of any contributors may be used to endorse or promote products derived
-        from this software without specific prior written permission.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-    COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-    ----
+3. Neither the name of the copyright holder nor the names of its contributors may
+   be used to endorse or promote products derived from this software without
+   specific prior written permission.
 
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-
-
-  unRAR license restriction
-  -------------------------
-
-    The decompression engine for RAR archives was developed using source 
-    code of unRAR program.
-    All copyrights to original unRAR code are owned by Alexander Roshal.
-
-    The license for original unRAR code has the following restriction:
-
-    The unRAR sources cannot be used to re-create the RAR compression algorithm, 
-    which is proprietary. Distribution of modified unRAR sources in separate form 
-    or as a part of other software is permitted, provided that it is clearly
-    stated in the documentation and source comments that the code may
-    not be used to develop a RAR (WinRAR) compatible archiver.
+---
 
 
-  --
-  Igor Pavlov
+
+
+BSD 2-clause License in 7-Zip code
+----------------------------------
+
+  The "BSD 2-clause License" is used for the XXH64 code in 7-Zip.
+    C/Xxh64.c
+
+  XXH64 code in 7-Zip was derived from the original XXH64 code developed by Yann Collet.
+
+  Copyright (c) 2012-2021 Yann Collet.
+  Copyright (c) 2023-2025 Igor Pavlov.
+
+Text of the "BSD 2-clause License"
+----------------------------------
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+---
+
+
+
+
+unRAR license restriction
+-------------------------
+
+The decompression engine for RAR archives was developed using source
+code of unRAR program.
+All copyrights to original unRAR code are owned by Alexander Roshal.
+
+The license for original unRAR code has the following restriction:
+
+  The unRAR sources cannot be used to re-create the RAR compression algorithm,
+  which is proprietary. Distribution of modified unRAR sources in separate form
+  or as a part of other software is permitted, provided that it is clearly
+  stated in the documentation and source comments that the code may
+  not be used to develop a RAR (WinRAR) compatible archiver.
+
+--

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,7 @@ build:
 
 requirements:
   build:
+    - {{ stdlib('c') }}
     - {{ compiler('cxx') }}
   run_constrained:
     - 7za <0.0.0a

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "7zip" %}
-{% set version = "24.09" %}
+{% set version = "25.01" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://downloads.sourceforge.net/project/sevenzip/7-Zip/{{ version }}/7z{{ version.replace('.', '') }}-src.7z
-  sha256: a33569eed0ce628fb9ceb9f46ac257d3f36b3966471667e65ba01878673c9faa
+  sha256: 2aed39b8f1238464475e9de7dda169a5e873a1dc8bbf4f664b943eaba5620181
 
 build:
   number: 0


### PR DESCRIPTION
7zip 25.01

**Destination channel:** defaults

### Links

- [PKG-10879](https://anaconda.atlassian.net/browse/PKG-10879) 
- [Upstream repository](https://sourceforge.net/projects/sevenzip/)
- [Upstream changelog/diff](https://www.7-zip.org/history.txt)
- Relevant dependency PRs:
  - N/A

### Explanation of changes:

- 7zip v25.01 upgrade to mitigate CVE-2025-11001

### Notes:

- The Anaconda Linter would fail when there is a list on the `about -> license_file` field.
- The final conda package includes `*.lib` files under `$PREFIX\Library\lib` directory. `bld.bat` is intentionally copying them.


[PKG-10879]: https://anaconda.atlassian.net/browse/PKG-10879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ