### PR TITLE
Fix win-arm64 build by selecting arm64 nmake platform.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -2,7 +2,11 @@ set "PLATFORM=x64"
 if "%SUBDIR%"=="win-arm64" set "PLATFORM=arm64"
 
 cd CPP\7zip
-nmake PLATFORM=%PLATFORM% NEW_COMPILER=1 MY_DYNAMIC_LINK=1
+if "%SUBDIR%"=="win-arm64" (
+  nmake PLATFORM=%PLATFORM% NEW_COMPILER=1 MY_DYNAMIC_LINK=1 NO_ASM_GNU=1
+) else (
+  nmake PLATFORM=%PLATFORM% NEW_COMPILER=1 MY_DYNAMIC_LINK=1
+)
 
 copy Bundles\Alone7z\%PLATFORM%\7zr.exe %LIBRARY_PREFIX%\bin\7zr.exe
 copy Bundles\Alone\%PLATFORM%\7za.exe %LIBRARY_PREFIX%\bin\7za.exe

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,9 +1,12 @@
+set "PLATFORM=x64"
+if "%SUBDIR%"=="win-arm64" set "PLATFORM=arm64"
+
 cd CPP\7zip
-nmake PLATFORM=x64 NEW_COMPILER=1 MY_DYNAMIC_LINK=1
+nmake PLATFORM=%PLATFORM% NEW_COMPILER=1 MY_DYNAMIC_LINK=1
 
-copy Bundles\Alone7z\x64\7zr.exe %LIBRARY_PREFIX%\bin\7zr.exe
-copy Bundles\Alone\x64\7za.exe %LIBRARY_PREFIX%\bin\7za.exe
-copy UI\Console\x64\7z.exe %LIBRARY_PREFIX%\bin\7z.exe
+copy Bundles\Alone7z\%PLATFORM%\7zr.exe %LIBRARY_PREFIX%\bin\7zr.exe
+copy Bundles\Alone\%PLATFORM%\7za.exe %LIBRARY_PREFIX%\bin\7za.exe
+copy UI\Console\%PLATFORM%\7z.exe %LIBRARY_PREFIX%\bin\7z.exe
 
-for /d %%G in (dir Bundles\Format*) do copy %%G\x64\*.dll %LIBRARY_PREFIX%\bin\
-for /d %%G in (dir Bundles\Format*) do copy %%G\x64\*.lib %LIBRARY_PREFIX%\lib\
+for /d %%G in (dir Bundles\Format*) do copy %%G\%PLATFORM%\*.dll %LIBRARY_PREFIX%\bin\
+for /d %%G in (dir Bundles\Format*) do copy %%G\%PLATFORM%\*.lib %LIBRARY_PREFIX%\lib\

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,4 +1,0 @@
-cxx_compiler:        # [win]
-  - vs2017           # [win]
-c_compiler:          # [win]
-  - vs2017           # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2aed39b8f1238464475e9de7dda169a5e873a1dc8bbf4f664b943eaba5620181
 
 build:
-  number: 0
+  number: 1
   skip: true  # [not win or win32]
 
 requirements:


### PR DESCRIPTION
bld.bat hardcoded PLATFORM=x64, which produced x64 objects while conda-build links for ARM64 on win-arm64 (LNK1112). Use SUBDIR to pick arm64 and copy artifacts from the matching output directory.
