### PR TITLE
v26.02

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -1,5 +1,7 @@
 anaconda_config_version: 1
 upstream_sources:
-  - webpage:
-      url: https://sourceforge.net/projects/sevenzip/files/7-Zip/
-      regex: 7-Zip/([\d.]+)/
+  - github:
+      identifier: ip7z/7zip
+      use_max_tag: true
+      from_pattern: ^(\d+\.\d+)$
+      to_pattern: \1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,16 @@
 {% set name = "7zip" %}
-{% set version = "25.01" %}
+{% set version = "26.02" %}
 
 package:
   name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://downloads.sourceforge.net/project/sevenzip/7-Zip/{{ version }}/7z{{ version.replace('.', '') }}-src.7z
-  sha256: 2aed39b8f1238464475e9de7dda169a5e873a1dc8bbf4f664b943eaba5620181
+  url: https://github.com/ip7z/7zip/releases/download/{{ version }}/7z{{ version.replace('.', '') }}-src.7z
+  sha256: c7502dd4557481f52ccf1b3e680329f1fdd207e79a25544afeb3106325474944
 
 build:
-  number: 1
+  number: 0
   skip: true  # [not win or win32]
 
 requirements:
@@ -36,7 +36,7 @@ about:
   description: |
     7-Zip is a file archiver with a high compression ratio.
   summary: 7-Zip is a file archiver with a high compression ratio.
-  dev_url: https://sourceforge.net/p/sevenzip/
+  dev_url: https://github.com/ip7z/7zip
   doc_url: https://www.7-zip.org
 extra:
   recipe-maintainers:


### PR DESCRIPTION
7zip 26.02

**Destination channel:**  defaults

### Links

- [PKG-16641](https://anaconda.atlassian.net/browse/PKG-16641) 
- [Upstream repository](https://github.com/ip7z/7zip/)

### Explanation of changes:

- Reset build number
- Bump version and SHA
- Update to new upstream URLs. 


[PKG-16547]: https://anaconda.atlassian.net/browse/PKG-16547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-16641]: https://anaconda.atlassian.net/browse/PKG-16641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ